### PR TITLE
Update Privacy Policy (ja/en): EEA default OFF, UMP consent, Ads/Analytics, Remote Config

### DIFF
--- a/en/privacy-policy.html
+++ b/en/privacy-policy.html
@@ -77,7 +77,7 @@
             <div class="page-header">
                 <h1>Privacy Policy</h1>
                 <p class="page-description">How VoicyCare handles personal data.</p>
-                <p class="last-updated">Last updated: 2025-08-05</p>
+                <p class="last-updated">Last updated: 2025-08-20</p>
             </div>
 
             <div class="policy-content">
@@ -150,7 +150,31 @@
                             <h4>Dropbox API</h4>
                             <p>Used for cloud integration; Dropbox's policy applies.</p>
                         </div>
+                        <div class="service-item">
+                            <h4>Firebase Analytics</h4>
+                            <p>Collects anonymized usage data to improve quality. Default OFF in EEA/UK and ON elsewhere. Users can change this anytime in Settings.</p>
+                        </div>
+                        <div class="service-item">
+                            <h4>Firebase Crashlytics</h4>
+                            <p>Collects anonymous crash reports (stack traces, OS version) to improve stability. No personally identifying information is included.</p>
+                        </div>
+                        <div class="service-item">
+                            <h4>Google Mobile Ads (AdMob)</h4>
+                            <p>Serves App Open Ads, banners, and interstitials. In EEA/UK we use Google UMP to obtain consent and show non-personalized ads (NPA) if consent is not given. On iOS we request ATT if required.</p>
+                        </div>
+                        <div class="service-item">
+                            <h4>Firebase Remote Config</h4>
+                            <p>Delivers policy values like ad cooldowns or accessibility suppressions remotely. It does not store personal data; only numeric/boolean config values.</p>
+                        </div>
                     </div>
+                    <h3>5.2 Consent and Defaults for Ads/Analytics</h3>
+                    <ul class="policy-list">
+                        <li><strong>Analytics default:</strong> OFF in EEA/UK, ON elsewhere. Applied only on first run; afterwards we always respect the user’s in-app preference (Settings → “Anonymous usage stats”).</li>
+                        <li><strong>Ad consent:</strong> In EEA/UK, consent is managed via UMP. Without consent we show only NPA ads. Outside EEA we typically use NPA unless the user consents to PA.</li>
+                        <li><strong>Accessibility:</strong> We may suppress ads during playback or when VoiceOver is active.</li>
+                        <li><strong>Frequency caps:</strong> App Open/interstitial ads have cooldowns and session caps to avoid excessive display (tunable via Remote Config).</li>
+                        <li><strong>User choice:</strong> Users can change consent and analytics settings anytime in the app.</li>
+                    </ul>
                 </section>
 
                 <section class="policy-section">

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -81,7 +81,7 @@
                 <p class="page-description">
                     VoicyCare聴覚支援音楽プレイヤーにおける個人情報の取り扱いについて
                 </p>
-                <p class="last-updated">最終更新日：2025年8月5日</p>
+                <p class="last-updated">最終更新日：2025年8月20日</p>
             </div>
 
             <div class="policy-content">
@@ -202,7 +202,31 @@
                             <h4>Dropbox API</h4>
                             <p>クラウドストレージ連携のため。Dropboxのプライバシーポリシーが適用されます。</p>
                         </div>
+                        <div class="service-item">
+                            <h4>Firebase Analytics</h4>
+                            <p>アプリの品質改善のため匿名化された利用状況データを収集します。欧州経済領域（EEA）/英国では既定で収集OFF、その他地域では既定ONとし、いずれもアプリ内の設定からユーザーがいつでも変更できます。</p>
+                        </div>
+                        <div class="service-item">
+                            <h4>Firebase Crashlytics</h4>
+                            <p>クラッシュ発生時に匿名のクラッシュレポート（スタックトレース、OSバージョンなど）を収集し、安定性向上に利用します。個人を特定する情報は含みません。</p>
+                        </div>
+                        <div class="service-item">
+                            <h4>Google Mobile Ads（AdMob）</h4>
+                            <p>App Open Ads、バナー、インタースティシャル広告を配信します。EEA/英国ではGoogle UMP（User Messaging Platform）により同意を確認し、同意がない場合は非パーソナライズド広告（NPA）のみを表示します。iOSでは必要に応じてATT（App Tracking Transparency）の確認を行います。</p>
+                        </div>
+                        <div class="service-item">
+                            <h4>Firebase Remote Config</h4>
+                            <p>広告のクールダウンや表示抑制（再生中/VoiceOver時）などアプリのポリシー値を遠隔で調整します。個人データは保持せず、数値やブール値などの設定値のみを配信します。</p>
+                        </div>
                     </div>
+                    <h3>5.2 広告・計測に関する同意と既定</h3>
+                    <ul class="policy-list">
+                        <li><strong>アナリティクスの既定</strong>：EEA/英国では既定OFF、その他地域は既定ON。初回のみ地域既定を適用し、その後はユーザー設定を常に優先します（設定画面「匿名の利用統計」から変更可能）。</li>
+                        <li><strong>広告の同意</strong>：EEA/英国ではUMPにより同意取得を行い、同意がない場合はNPAのみ表示します。非EEAでは通常NPAを基本とし、ユーザーが同意した場合に限りパーソナライズド広告（PA）を使用します。</li>
+                        <li><strong>アクセシビリティ配慮</strong>：再生中やVoiceOver有効時などは広告表示を抑制する場合があります。</li>
+                        <li><strong>頻度制御</strong>：アプリ起動時広告やインタースティシャルにはクールダウンやセッション上限を設け、過度な表示を避けます（Remote Configで調整）。</li>
+                        <li><strong>ユーザーの選択</strong>：同意や統計収集の設定はいつでもアプリ内から変更できます。</li>
+                    </ul>
                 </section>
 
                 <section class="policy-section">


### PR DESCRIPTION
更新内容（日本語/英語）
- EEA/UKはアナリティクス既定OFF、その他は既定ON（初回のみ適用、以降はユーザー設定を常に優先）
- UMP（User Messaging Platform）での同意取得。未同意時はNPA（非パーソナライズド）広告のみ
- Firebase Analytics/Crashlyticsの利用説明を追記（匿名・個人特定なし）
- AdMob（App Open Ads/バナー/インタースティシャル）の記載を追加
- Firebase Remote Configによる広告ポリシー調整（クールダウン、再生中/VoiceOver時抑制など）を明記
- 最終更新日を2025-08-20へ更新

Updates (EN)
- Analytics default: OFF in EEA/UK, ON elsewhere (applied only on first run; afterwards user preference is always respected)
- Consent via Google UMP; show only NPA without consent
- Clarify Firebase Analytics/Crashlytics (anonymous, no PII)
- Add AdMob (App Open Ads, banners, interstitials)
- Note Firebase Remote Config for policy tuning (cooldowns, suppressions during playback/VoiceOver)
- Last updated: 2025-08-20

Files
- privacy-policy.html (JA)
- en/privacy-policy.html (EN)
