### PR TITLE
Fix presets display and GitHub link

### DIFF
--- a/en/index.html
+++ b/en/index.html
@@ -232,11 +232,11 @@
           <div class="feature-card">
             <div class="feature-icon">🎵</div>
             <h3 class="feature-title">Volume & Sound Presets</h3>
-            <p class="feature-description">Five volume presets and simple/advanced sound settings.</p>
+            <p class="feature-description">Three volume presets and simple/advanced sound settings.</p>
             <ul class="feature-list">
-              <li>30% / 70% / 100% / 130% / 150%</li>
-              <li>Soft (0.9x) / Quiet (0.9x) / Clear (1.2x)</li>
-              <li>EQ presets (Treble/Bass/Vocal/Flat)</li>
+              <li>40% / 70% / 100%</li>
+              <li>Soft (0.9x) / Quiet (0.7x) / Clear (1.2x)</li>
+              <li>EQ presets (Classic/Vocal/Rock/Flat)</li>
             </ul>
           </div>
           <div class="feature-card">
@@ -429,7 +429,7 @@
               <h4>Support</h4>
               <ul>
                 <li><a href="#contact">Contact</a></li>
-                <li><a href="https://github.com/nobuo-imai/VoicyCare" target="_blank">GitHub</a></li>
+                <li><a href="https://github.com/n-imai/" target="_blank" rel="noopener noreferrer">GitHub</a></li>
               </ul>
             </div>
           </div>

--- a/index.html
+++ b/index.html
@@ -235,13 +235,13 @@
                     <div class="feature-icon">🎵</div>
                     <h3 class="feature-title">音量・音質プリセット</h3>
                     <p class="feature-description">
-                        5段階の音量プリセットと、シンプル/詳細を切り替えできる音質設定で、最適な聴こえを簡単に。
-                        具体的なプリセット値を明記し、選びやすくしました。
+                        3段階の音量プリセットと、シンプル/詳細を切り替えできる音質設定で、最適な聴こえを簡単に。
+                        プリセット値を明記し、選びやすくしました。
                     </p>
                     <ul class="feature-list">
-                        <li>音量プリセット: 30% / 70% / 100% / 130% / 150%</li>
-                        <li>音質プリセット: やわらか(0.8倍) / 静か(0.9倍) / はっきり(1.2倍)</li>
-                        <li>イコライザープリセット（高音/低音/ボーカル/フラット）</li>
+                        <li>音量プリセット: 40% / 70% / 100%</li>
+                        <li>音質プリセット: やわらか(0.9倍) / 静か(0.7倍) / はっきり(1.2倍)</li>
+                        <li>イコライザープリセット（クラシック/ボーカル/ロック/フラット）</li>
                     </ul>
                 </div>
 
@@ -481,7 +481,7 @@
                         <h4>サポート</h4>
                         <ul>
                             <li><a href="#contact">お問い合わせ</a></li>
-                            <li><a href="https://github.com/nobuo-imai/VoicyCare" target="_blank">GitHub</a></li>
+                            <li><a href="https://github.com/n-imai/" target="_blank" rel="noopener noreferrer">GitHub</a></li>
                         </ul>
                     </div>
                 </div>


### PR DESCRIPTION
- Update JA/EN preset text to match app implementation (Volume 40/70/100; Sound Soft 0.9x / Quiet 0.7x / Clear 1.2x; EQ Classic/Vocal/Rock/Flat)\n- Replace GitHub link with https://github.com/n-imai/\n- Minor copy consistency